### PR TITLE
ACL/Adminhtml fix following Magento security patch SUPEE-6285

### DIFF
--- a/app/code/community/GoodsCloud/Sync/controllers/Adminhtml/GetAwsController.php
+++ b/app/code/community/GoodsCloud/Sync/controllers/Adminhtml/GetAwsController.php
@@ -8,4 +8,9 @@ class GoodsCloud_Sync_Adminhtml_GetAwsController
         $api = Mage::getModel('goodscloud_sync/api_factory')->getApi();
         $this->getResponse()->setBody($api->get_session()->auth->access);
     }
+
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('system/config/goodscloud_sync');
+    }
 }


### PR DESCRIPTION
Following Magento SUPEE-6285, Adminhtml controllers require override of _isAllowed. Without conforming to this new requirement, the fine-grained permissions are ignored, and access denied. More here: http://magento.stackexchange.com/questions/73646/access-denied-errors-after-installing-supee-6285